### PR TITLE
[bug] selects python3 explicitly in igcc

### DIFF
--- a/igcc
+++ b/igcc
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import sys
 import os


### PR DESCRIPTION
This is a one line change to `./igcc` to explicitly select python3 over python2 for systems that have both installed.