### PR TITLE
use pyreadline3 to make it work on Windows

### DIFF
--- a/igcc/run.py
+++ b/igcc/run.py
@@ -1,7 +1,10 @@
 import argparse
 import itertools
 import re
-import readline
+try:
+    import readline  # Linux/macOS
+except ImportError:
+    import pyreadline3 as readline  # Windows
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -11,8 +14,8 @@ from rich import print
 
 import igcc.utils
 
-readline.parse_and_bind("tab: complete")
-
+if hasattr(readline, "parse_and_bind"):
+    readline.parse_and_bind("tab: complete") # for Linux/macOS only
 
 with open(igcc.utils.get_asset_dir() / "config.yaml") as fp:
     CONFIG = argparse.Namespace(**yaml.safe_load(fp))


### PR DESCRIPTION
### Changes:
The equivalent of the `readline` module for Windows is `pyreadline3`, so I updated the code to import that if possible. However, `pyreadline3` does not have the `parse_and_bind` method, so I added a check to call that method only if it exists.

### Tested:
✅ It runs successfully on Windows with Python 3.13